### PR TITLE
chore: Bump Singer SDK to 0.10.0

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -43,3 +43,6 @@ plugins:
       default_target_schema: raw_${MELTANO_EXTRACT__LOAD_SCHEMA}
       before_run_sql: CREATE SCHEMA IF NOT EXISTS raw_${MELTANO_EXTRACT__LOAD_SCHEMA};
       max_batch_rows: 10000
+
+environments:
+- name: dev

--- a/poetry.lock
+++ b/poetry.lock
@@ -585,7 +585,7 @@ python-versions = "*"
 
 [[package]]
 name = "singer-sdk"
-version = "0.9.0"
+version = "0.10.0"
 description = "A framework for building Singer taps"
 category = "main"
 optional = false
@@ -797,7 +797,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "<3.11,>=3.7.1"
-content-hash = "8800278ddcec51398ff3e180ccaf7e9e85540e4f1e94a1583b1f5603904076d2"
+content-hash = "a0e3ad22e2922a61a8e7d049c7a1cb7f4b1dd470e3b05e28c89de27b06e25800"
 
 [metadata.files]
 attrs = [
@@ -1218,8 +1218,8 @@ simplejson = [
     {file = "simplejson-3.11.1.win32-py3.5.exe", hash = "sha256:c76d55d78dc8b06c96fd08c6cc5e2b0b650799627d3f9ca4ad23f40db72d5f6d"},
 ]
 singer-sdk = [
-    {file = "singer-sdk-0.9.0.tar.gz", hash = "sha256:ced6389a7d30bb94b4f2249f0bee4105812d55f564b0de38087d942790ed34a1"},
-    {file = "singer_sdk-0.9.0-py3-none-any.whl", hash = "sha256:573fac974e7133f0d2e3dcbac69672058e0f01f008bba52d7ce52132779d8e48"},
+    {file = "singer-sdk-0.10.0.tar.gz", hash = "sha256:347b34d37541cd55678af3e574807c45b539cd538a91f28f36e0c0c51676098d"},
+    {file = "singer_sdk-0.10.0-py3-none-any.whl", hash = "sha256:f9db52db23a07f9243ed6be5dd9ed5b204a9eef48ef49d0c4f8f1d809e0df44e"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ documentation = "https://github.com/edgarrmondragon/tap-bitso#readme"
 
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
-singer-sdk = "==0.9.0"
+singer-sdk = "==0.10.0"
 structlog = "==22.1.0"
 typing-extensions = "^4.3.0"
 

--- a/tap_bitso/client.py
+++ b/tap_bitso/client.py
@@ -89,25 +89,6 @@ class BitsoStream(RESTStream):
             params["book"] = context["book"]
         return params
 
-    def get_next_page_token(
-        self, response: requests.Response, previous_token: str | None
-    ) -> Any | None:
-        """Return token identifying next page or None if all records have been read.
-
-        Args:
-            response: A raw `requests.Response`_ object.
-            previous_token: Previous pagination reference.
-
-        Returns:
-            Reference value to retrieve next page.
-
-        .. _requests.Response:
-            https://docs.python-requests.org/en/latest/api/#requests.Response
-        """
-        token = super().get_next_page_token(response, previous_token)
-        self.logger.debug("New page token %s", token)
-        return token
-
     @property
     def partitions(self) -> list[dict] | None:
         """Return a list of partition key dicts (if applicable), otherwise None.


### PR DESCRIPTION
- Bump Singer SDK to `0.10.0`
- Add `dev` environment to `meltano.yml`
- Remove `get_next_page_token` implementation
